### PR TITLE
Added monitoring by pools

### DIFF
--- a/pve-monitor.conf
+++ b/pve-monitor.conf
@@ -33,3 +33,10 @@ storage local {
     disk 80 90
     node pyrit
 }
+
+#pool example
+pool Sample {
+    mem 98 100
+    cpu 90 95
+    disk 90 95
+}


### PR DESCRIPTION
New features:
1. Added --pools option to moniitor everything defined in cluster's pool according to choosen option from openvz/qemu/storage.

So there is no need to update all VM's definitions in pve-monitor.conf everytime when new VM is added. Just ask your cluster administrator to add VMs for monitoring to pool and define it once in your conf.

You can also define storages, qemu and openvz in script config separately with different gauges, it will be preffered if object exists in defined pools.
1. Monitoring options can be used together, for example pve-monitor.pl --openvz --qemu
2. Shorten output, for example, to fit text in SMS notification
   Removed OPENVZ/STORAGE/QEMU from each line of status text, left only in status summary.
3. Line break can be quickly changed from \n to <br> for better representation in nagios logs.
   Nagios will not record nothing more than one line of script output. When escape_html_tags is on in cgi.cfg you can put it in plugin output. In notification template commands it can be simply removed.
4. Disable Nagios EPN. Usable when script should be called from another perl version. to force enable change to "+epn".
   We use perl 5.18 on monitoring host with system perl 5.8, so needed to install separate perl to make Net::Proxmox::VE working properly.
